### PR TITLE
Fix bugs

### DIFF
--- a/nfa.cpp
+++ b/nfa.cpp
@@ -170,7 +170,7 @@ main(int argc, char **argv)
 				}
 			}
 			
-			if((lines[0])[len-1] == '\n')//если файл кончился не переводом строки, то про последнее смещение забывать не надо.
+			if((lines[0])[len-1] == '\n')/*if at the end file not '\n', then we not forgot last offset */
 			  --num_lines;
 
 

--- a/nfa.cpp
+++ b/nfa.cpp
@@ -160,7 +160,7 @@ main(int argc, char **argv)
 			u32 * table = (u32 *) malloc(sizeof(u32) * strlen(*lines));
 			table[0] = 0;
 			int num_lines = 0;
-	
+
 			int len = strlen(lines[0]);
 			for (int i = 0; i < len; i++) {
 				if ((lines[0])[i] == '\n') {
@@ -169,8 +169,12 @@ main(int argc, char **argv)
 				
 				}
 			}
-			-- num_lines;	
-	
+			
+			if((lines[0])[len-1] == '\n')//если файл кончился не переводом строки, то про последнее смещение забывать не надо.
+			  --num_lines;
+
+
+
 			
 			cudaMalloc((void**)&device_line_table, sizeof (u32) * (len ));		
 			cudaMalloc((void**)&device_line, sizeof (char) * (len + 1));		
@@ -180,8 +184,14 @@ main(int argc, char **argv)
 			
 			endCopyStringsToDevice = CycleTimer::currentSeconds();
 
-			u32 numRegexes = 1;
-			pMatch(device_line, device_line_table, num_lines, 1, timerOn, device_regex, &numRegexes, lines, table);
+			u32 host_regex_table[1]; /*offsets to regexes on host*/
+			u32 *device_regex_table; /*this array will contain host_regex_table*/
+			host_regex_table[0]=0;   /*in case of one regex offset must be 0*/
+			cudaMalloc((void**)&device_regex_table, sizeof (u32) );
+			cudaMemcpy(device_regex_table, host_regex_table, sizeof(u32), cudaMemcpyHostToDevice);/*copy regex offset to device*/
+			pMatch(device_line, device_line_table, num_lines, 1, timerOn, device_regex, device_regex_table, lines, table);
+
+			
 			endPMatch = CycleTimer::currentSeconds();
 		}
 		// match a bunch of regexs

--- a/nfautil.cpp
+++ b/nfautil.cpp
@@ -507,7 +507,7 @@ void readFile (char *fileName, char ***lines, int *lineIndex) {
 			if (newLen == 0) {
 				fputs("Error reading file", stderr);
 			} else {
-				source[++newLen] = '\0'; /* Just to be safe. */
+				source[newLen] = '\0'; /* Just to be safe. */
 			}
 		}
 		fclose(fp);

--- a/pnfa.cu
+++ b/pnfa.cu
@@ -291,7 +291,7 @@ void pMatch(char * bigLine, u32 * tableOfLineStarts, int numLines, int numRegexs
 		}
 	}
 
-	cudaFree(&devResult);
-	cudaFree(&bigLine);
-    cudaFree(&tableOfLineStarts);
+	cudaFree(devResult);
+	cudaFree(bigLine);
+    cudaFree(tableOfLineStarts);
 }

--- a/pnfa.cuh
+++ b/pnfa.cuh
@@ -10,8 +10,13 @@
 #define PUSH(l, state) l->s[l->n++] = state
 #define POP(l) l->s[--(l->n)]; 
 
-__device__ State *states;
-__device__ static int pnstate;
+__device__ __shared__ State *states; /*this variable used in ppost2nfa
+                            it must be local for each block
+                            simple way to do this use __shared__
+                          */
+__device__ __shared__  int pnstate; /*this variable too must be local
+                                            for each blocks*/
+
 __device__ State pmatchstate = { Match };	/* matching state */
 
 

--- a/testbench/runtests.sh
+++ b/testbench/runtests.sh
@@ -29,7 +29,7 @@ do
 	do
 		testcase=${teststrings[$i]}
 		#echo $testcase
-		if diff <(../nfa -f $file $testcase) <(egrep $testcase $file) >> RESULTS; then
+		if diff <(../nfa -f $file $testcase) <(egrep -x $testcase $file) >> RESULTS; then
 			cat /dev/null
 		else
 			pass=0
@@ -41,7 +41,7 @@ done
 #special test for .*
 for file in $FILES
 do	
-	if diff <(../nfa -f $file '.*') <(egrep '.*' $file) >> RESULTS; then
+	if diff <(../nfa -f $file '.*') <(egrep -x '.*' $file) >> RESULTS; then
 		cat /dev/null
 	else
 		pass=0


### PR DESCRIPTION
Hi, cuda-grep developers!
I fixed some bugs, that crashes cuda-grep on cuda 5.

(*) at nfa.cpp the last line was forgotten if file does't contain '\n' at the end
(*) in main function pMatch is called and in third arg the pointer to numRegexes is passed, 
and this pointer dereference in device and kernel crash.

(*) this line wrong.    source[++newLen] = '\0';

(*) cudaFree(&devResult); i don't know what prototype has this function later, but now
cudaError_t cudaFree ( void * devPtr) 

(*) in tests grep must match whole line, but not subline. key -x does this.